### PR TITLE
Fix: Last news should not request another page from the backend.

### DIFF
--- a/templates/news.gohtml
+++ b/templates/news.gohtml
@@ -1,8 +1,12 @@
+{{ if eq .NextPage 0 }}
+<tr>
+{{ else }}
 <tr
   hx-get="/news?page={{ .NextPage }}"
   hx-trigger="revealed"
   hx-swap="afterend"
 >
+{{ end }}
   <th class="table-light" scope="row">
     <a href="{{ .PageNews.URL }}">{{ .PageNews.Title }}</a>
     <small class="text-muted">{{ .PageNews.Feed }}</small>


### PR DESCRIPTION
When we reach the last news in memory we should stop adding HTMX tag to request more data from the backend as the item is revealed.