### PR TITLE
Automatically add HTTPS if url scheme is not set

### DIFF
--- a/morningpost.go
+++ b/morningpost.go
@@ -142,6 +142,9 @@ func (m *MorningPost) parsePageFromQueryString(params url.Values) (int, error) {
 }
 
 func (m *MorningPost) FindFeeds(URL string) []Feed {
+	if !strings.HasPrefix(URL, "http") {
+		URL = "https://" + URL
+	}
 	req, err := http.NewRequest(http.MethodGet, URL, nil)
 	if err != nil {
 		return nil

--- a/morningpost_test.go
+++ b/morningpost_test.go
@@ -1036,6 +1036,22 @@ func TestFindFeeds_ReturnsExpectedFeedsGivenApplicationRSSXMLContentType(t *test
 	}
 }
 
+func TestFindFeeds_ReturnsExpectedFeedGivenURLWithoutScheme(t *testing.T) {
+	t.Parallel()
+	want := []morningpost.Feed{
+		{
+			Endpoint: "https://domainwheel.com/feed/",
+			Type:     morningpost.FeedTypeRSS,
+		},
+	}
+	m := newMorningPostWithFakeStoreAndNoOutput(t)
+	// if this test fails check if the URL is still a valid feed
+	got := m.FindFeeds("domainwheel.com/feed/")
+	if !cmp.Equal(want, got) {
+		t.Fatal(cmp.Diff(want, got))
+	}
+}
+
 func TestFindFeeds_ReturnsExpectedFeedsGivenApplicationXMLContentTypeAndRSSData(t *testing.T) {
 	t.Parallel()
 	ts := newServerWithContentTypeAndBodyResponse(t, "application/xml", "testdata/rss.xml")


### PR DESCRIPTION
Add a new test to check if HTTPS is added automatically if the given URL does not start with `http`